### PR TITLE
Fix response error handling of fetch function

### DIFF
--- a/src/apps/rambler/BingMapsImageProvider.js
+++ b/src/apps/rambler/BingMapsImageProvider.js
@@ -48,7 +48,10 @@ class BingMapsImageProvider extends ImageProvider {
         url = url.replace( /\{uriScheme\}/g, opts.uriScheme || BingMapsImageProvider.DefaultUriScheme );
 
         fetch( url )
-            .then( response => response.json() )
+            .then( response => {
+                return response.ok ?
+                    response.json() : Promise.reject( Error( response.statusText ) );
+            } )
             .then( json => {
                 this._analyze_matadata( json, opts );
                 this._status = Status.READY;

--- a/src/mapray/CloudDemProvider.js
+++ b/src/mapray/CloudDemProvider.js
@@ -30,7 +30,10 @@ class CloudDemProvider extends DemProvider {
 
         fetch( this._makeURL( z, x, y ), { headers: this._headers,
                                            signal:  actrl.signal } )
-            .then( response => response.arrayBuffer() )
+            .then( response => {
+                return response.ok ?
+                    response.arrayBuffer() : Promise.reject( Error( response.statusText ) );
+            } )
             .then( buffer => {
                 // データ取得に成功
                 callback( buffer );

--- a/src/mapray/SceneLoader.js
+++ b/src/mapray/SceneLoader.js
@@ -116,7 +116,8 @@ class SceneLoader {
         fetch( tr.url, this._make_fetch_params( tr ) )
             .then( response => {
                 this._check_cancel();
-                return response.json();
+                return response.ok ?
+                    response.json() : Promise.reject( Error( response.statusText ) );
             } )
             .then( oscene => {
                 // JSON データの取得に成功
@@ -226,7 +227,8 @@ class SceneLoader {
         fetch( tr.url, this._make_fetch_params( tr ) )
             .then( response => {
                 this._check_cancel();
-                return response.json();
+                return response.ok ?
+                    response.json() : Promise.reject( Error( response.statusText ) );
             } )
             .then( json => {
                 // モデルデータの取得に成功
@@ -269,7 +271,8 @@ class SceneLoader {
         fetch( tr.url, this._make_fetch_params( tr ) )
             .then( response => {
                 this._check_cancel();
-                return response.arrayBuffer();
+                return response.ok ?
+                    response.arrayBuffer() : Promise.reject( Error( response.statusText ) );
             } )
             .then( buffer => {
                 // バイナリデータの取得に成功

--- a/src/mapray/StandardDemProvider.js
+++ b/src/mapray/StandardDemProvider.js
@@ -45,7 +45,10 @@ class StandardDemProvider extends DemProvider {
         fetch( this._makeURL( z, x, y ), { credentials: this._credentials,
                                            headers:     this._headers,
                                            signal:      actrl.signal } )
-            .then( response => response.arrayBuffer() )
+            .then( response => {
+                return response.ok ?
+                    response.arrayBuffer() : Promise.reject( Error( response.statusText ) );
+            } )
             .then( buffer => {
                 // データ取得に成功
                 callback( buffer );


### PR DESCRIPTION
## 概要

fetch() が返す Promise オブジェクトは、ネットワークエラーのとき Rejected になるが、サーバーからのレンスポンスエラーは Rejected にならない。

サーバーからのレンスポンスエラーは response.ok の値で判断しなければならない。

つまり、次のような部分を

```javascript
fetch().then( response => response.XXX() )
```

次のように変更する。

```javascript
fetch().then( response => {
    return response.ok ?
        response.XXX() : Promise.reject( Error( response.statusText ) );
} )
```

## 結論

以下のファイルの fetch() 呼び出し部分を変更した。

```
src/mapray/CloudDemProvider.js
src/mapray/StandardDemProvider.js
src/mapray/SceneLoader.js
src/apps/rambler/BingMapsImageProvider.js
```

## 参考

* [Fetch API が 4xx エラーを reject してくれない](https://blog.mudatobunka.org/entry/2016/04/26/092518)