### PR TITLE
Remove babel es2015

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "babel-loader": "^6.2.10",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-env": "^1.7.0",
-    "babel-preset-es2015": "^6.18.0",
     "cross-env": "^5.1.0",
     "jsdoc": "^3.5.0",
     "raw-loader": "^0.5.1",

--- a/src/apps/rambler/BingMapsImageProvider.js
+++ b/src/apps/rambler/BingMapsImageProvider.js
@@ -48,7 +48,10 @@ class BingMapsImageProvider extends ImageProvider {
         url = url.replace( /\{uriScheme\}/g, opts.uriScheme || BingMapsImageProvider.DefaultUriScheme );
 
         fetch( url )
-            .then( response => response.json() )
+            .then( response => {
+                return response.ok ?
+                    response.json() : Promise.reject( Error( response.statusText ) );
+            } )
             .then( json => {
                 this._analyze_matadata( json, opts );
                 this._status = Status.READY;

--- a/src/mapray/CloudDemProvider.js
+++ b/src/mapray/CloudDemProvider.js
@@ -30,7 +30,10 @@ class CloudDemProvider extends DemProvider {
 
         fetch( this._makeURL( z, x, y ), { headers: this._headers,
                                            signal:  actrl.signal } )
-            .then( response => response.arrayBuffer() )
+            .then( response => {
+                return response.ok ?
+                    response.arrayBuffer() : Promise.reject( Error( response.statusText ) );
+            } )
             .then( buffer => {
                 // データ取得に成功
                 callback( buffer );

--- a/src/mapray/SceneLoader.js
+++ b/src/mapray/SceneLoader.js
@@ -116,7 +116,8 @@ class SceneLoader {
         fetch( tr.url, this._make_fetch_params( tr ) )
             .then( response => {
                 this._check_cancel();
-                return response.json();
+                return response.ok ?
+                    response.json() : Promise.reject( Error( response.statusText ) );
             } )
             .then( oscene => {
                 // JSON データの取得に成功
@@ -226,7 +227,8 @@ class SceneLoader {
         fetch( tr.url, this._make_fetch_params( tr ) )
             .then( response => {
                 this._check_cancel();
-                return response.json();
+                return response.ok ?
+                    response.json() : Promise.reject( Error( response.statusText ) );
             } )
             .then( json => {
                 // モデルデータの取得に成功
@@ -269,7 +271,8 @@ class SceneLoader {
         fetch( tr.url, this._make_fetch_params( tr ) )
             .then( response => {
                 this._check_cancel();
-                return response.arrayBuffer();
+                return response.ok ?
+                    response.arrayBuffer() : Promise.reject( Error( response.statusText ) );
             } )
             .then( buffer => {
                 // バイナリデータの取得に成功

--- a/src/mapray/StandardDemProvider.js
+++ b/src/mapray/StandardDemProvider.js
@@ -45,7 +45,10 @@ class StandardDemProvider extends DemProvider {
         fetch( this._makeURL( z, x, y ), { credentials: this._credentials,
                                            headers:     this._headers,
                                            signal:      actrl.signal } )
-            .then( response => response.arrayBuffer() )
+            .then( response => {
+                return response.ok ?
+                    response.arrayBuffer() : Promise.reject( Error( response.statusText ) );
+            } )
             .then( buffer => {
                 // データ取得に成功
                 callback( buffer );


### PR DESCRIPTION
## 概要

npm による導入時に次の警告が表示されたので何とかする。

```
$ npm install
npm WARN deprecated babel-preset-es2015@6.24.1: Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!
```

## 原因

jozoprj/inou の d1569f9e44b2bcda333bedf89b10c40a62da005f で package.json に babel-preset-env が追加され、babel-preset-es2015 は必要なくなった。

## 結論

依存パッケージ babel-preset-es2015 を削除した。

```
$ npm uninstall babel-preset-es2015 --save-dev
```


* Ubuntu ビルド ✅
* Windows ビルド ✅


## 参考

* [babel-preset-envの使い方（babel-preset-es2015からの移行）](https://dackdive.hateblo.jp/entry/2018/01/18/100000)
