### PR TITLE
Fix flake corner lod

### DIFF
--- a/src/mapray/EmptyImageProvider.js
+++ b/src/mapray/EmptyImageProvider.js
@@ -8,6 +8,7 @@ import ImageProvider from "./ImageProvider";
  *
  * @memberof mapray
  * @extends mapray.ImageProvider
+ * @private
  */
 class EmptyImageProvider extends ImageProvider {
 

--- a/src/mapray/FlakeCollector.js
+++ b/src/mapray/FlakeCollector.js
@@ -300,10 +300,11 @@ class FlakeCollector {
      * </ul>
      * @param  {number} x  X 座標
      * @param  {number} y  Y 座標
+     * @param  {number} r  GOGS 原点からの距離 (Meters)
      * @return {number}    地表詳細レベル
      * @private
      */
-    _calcLOD( x, y )
+    _calcLOD( x, y, r )
     {
         var sinλ = Math.sin( x );
         var cosλ = Math.cos( x );
@@ -311,7 +312,6 @@ class FlakeCollector {
         var ey2   = ey * ey;
         var sinφ = (ey2 - 1) / (ey2 + 1);
         var cosφ =   2 * ey  / (ey2 + 1);
-        var     r = GeoMath.EARTH_RADIUS;
 
         // N
         var N = this._view_dir_N;
@@ -328,7 +328,7 @@ class FlakeCollector {
 
         // w U.V
         var  wU = this._view_dir_wU;
-        var wUV = GeoMath.dot3( wU, V );
+        var wUV = GeoMath.dot3( wU, V );  // > 0 (表示される Flake 前提なので正数)
 
         //          r Cos[φ]
         // 1/d = ---------------
@@ -367,11 +367,14 @@ class FlakeCollector {
         var my_min =  pi - (y + 1) * msize;
         var my_max =  pi - y * msize;
 
+        // GOCS 原点からの距離
+        var r = GeoMath.EARTH_RADIUS + flake.base_height;
+
         // 四隅の地表詳細レベル
-        rflake.lod_00 = this._calcLOD( mx_min, my_min );
-        rflake.lod_10 = this._calcLOD( mx_max, my_min );
-        rflake.lod_01 = this._calcLOD( mx_min, my_max );
-        rflake.lod_11 = this._calcLOD( mx_max, my_max );
+        rflake.lod_00 = this._calcLOD( mx_min, my_min, r );
+        rflake.lod_10 = this._calcLOD( mx_max, my_min, r );
+        rflake.lod_01 = this._calcLOD( mx_min, my_max, r );
+        rflake.lod_11 = this._calcLOD( mx_max, my_max, r );
     }
 
 

--- a/src/mapray/GeoMath.js
+++ b/src/mapray/GeoMath.js
@@ -462,7 +462,7 @@ class GeoMath {
      * @param  {mapray.Matrix}  dst                  結果を代入する行列
      * @return {mapray.Matrix}                       dst
      *
-     * @deprecated {@link maplay.GeoPoint.mlocs_to_gocs_matrix} の使用を推奨
+     * @deprecated {@link mapray.GeoPoint#getMlocsToGocsMatrix} の使用を推奨
      */
     static iscs_to_gocs_matrix( position, dst )
     {
@@ -512,7 +512,7 @@ class GeoMath {
      * @param  {number}         dst.height     高度 (Meters)
      * @return {object}                        dst
      *
-     * @deprecated {@link mapray.GeoPoint.setFromGocs} の使用を推奨
+     * @deprecated {@link mapray.GeoPoint#setFromGocs} の使用を推奨
      */
     static gocs_to_iscs( src, dst )
     {
@@ -695,7 +695,7 @@ class GeoMath {
      * @package
      * @see https://developers.google.com/kml/documentation/kmlreference#model
      *
-     * @deprecated {@link maplay.Orientation.transform_matrix} の使用を推奨
+     * @deprecated {@link mapray.Orientation#getTransformMatrix} の使用を推奨
      */
     static kml_model_matrix( heading, tilt, roll, scale, dst )
     {
@@ -934,10 +934,10 @@ class GeoPoint {
      *
      * @desc
      * <p>longitude, latitude, altitude の順序で格納されている配列 position によりプロパティを設定する。</p>
-     * <p>position の長は 2 または 3 で、長が 2 なら altitude は 0 に設定される。</p>
+     * <p>position の長さは 2 または 3 で、長さが 2 なら altitude は 0 に設定される。</p>
      *
      * @param  {number[]} position  [longitude, latitude, altitude] または [longitude, latitude]
-     * @return {GeoPoint} this
+     * @return {mapray.GeoPoint} this
      */
     setFromArray( position )
     {
@@ -956,7 +956,7 @@ class GeoPoint {
      * <p>地心直交座標 position を球面座標に変換して this に設定する。</p>
      *
      * @param  {mapray.Vector3} position  入力 GOCS 座標 (Meters)
-     * @return {GeoPoint}  this
+     * @return {mapray.GeoPoint}  this
      */
     setFromGocs( position )
     {
@@ -995,8 +995,8 @@ class GeoPoint {
     /**
      * @summary 地心直交座標として取得
      *
-     * @param  {Vector3} dst  結果を格納するオブジェクト
-     * @return {Vector3}      dst
+     * @param  {mapray.Vector3} dst  結果を格納するオブジェクト
+     * @return {mapray.Vector3}      dst
      */
     getAsGocs( dst )
     {

--- a/src/mapray/UpdatedTileArea.js
+++ b/src/mapray/UpdatedTileArea.js
@@ -98,6 +98,7 @@ class UpdatedTileArea {
  * @summary UpdatedTileArea のノード
  *
  * @memberof mapray.UpdatedTileArea
+ * @private
  */
 class Node {
 


### PR DESCRIPTION
地表断片の四隅の LOD の計算の誤りを 17998db で訂正しました。

具体的には FlakeCollector#_setCornerLODs() の LOD 計算で標高 0 として計算しているところを、地表断片の平均標高で計算するように訂正しました。

標高の高い場所を近くで見たときに地図画像の混合の質が低下する可能性がありましたが改善されました。

実験では富士山の頂上付近に近づくときに、予想より画像がボケる場合がありましたが、それが改善されました。